### PR TITLE
fix: avoid failures if event logos are placeholder

### DIFF
--- a/function/wingman/scrape.py
+++ b/function/wingman/scrape.py
@@ -41,7 +41,8 @@ def events() -> dict:
         event_id = int(event_url_path.split("/")[2])
 
         event_logo_path = item.css_first(".event-item-thumb img").attributes["src"]
-        event_logo_url = "https:{}".format(event_logo_path)
+        event_logo_path = re.sub(r"^/+", "", event_logo_path)
+        event_logo_url = "https://{}".format(event_logo_path)
 
         item = {
             "id": event_id,


### PR DESCRIPTION
if event logo URL on vlr.gg is `/img/vlr/tmp/vlr.png`, value of thumbnail URL posted to Discord Webhook will be `https:/img/vlr/tmp/vlr.png`, which fails to post.

https://stackoverflow.com/questions/53935198/in-my-discord-webhook-i-am-getting-the-error-embeds-0

> wrong format in icon_url, avatar_url, or url, all of them must be in http://, https://, (additionally for url that expects image, it can be attachment:// so long the image file is also attached to the request)